### PR TITLE
Add RCv2 FAQ warning

### DIFF
--- a/api-docs/getting-started/attach-network-intro.rst
+++ b/api-docs/getting-started/attach-network-intro.rst
@@ -12,6 +12,13 @@ Use the Cloud Networks virtual interface extension to:
 
 You can create a maximum of one virtual interface per instance per network.
 
+**IMPORTANT: Can I attach/detach a Cloud Network on a running RackConnected Cloud Server?**
+
+From `RackConnect v2.0 with Cloud Networks FAQ
+<https://support.rackspace.com/how-to/rackconnect-v20-with-cloud-networks-faq/>`_:
+
+    Attaching/detaching a Cloud Network on a running RackConnected Cloud Server causes the network stack to be reset, which will break the cloud server’s RackConnect connectivity. Therefore, we do not recommend attaching or detaching Cloud Networks to running RackConnect servers. If you do need to attach or detach a network, please contact your Support team prior to making the change.
+
 These examples walk you through the steps to create a virtual interface to a specified 
 network and attach the network to an existing server instance. The simple exercises show 
 you how to access the Cloud Networks virtual interface extension through nova client 


### PR DESCRIPTION
Add reference to RackConnect v2.0 with Cloud Networks FAQ. Can save a lot of grief.
